### PR TITLE
Add Windows MQTT screen control skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "auto_screen_switch"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+rumqttc = "0.24"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+windows = { version = "0.52", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,60 @@
+use clap::Parser;
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+use serde::Deserialize;
+use std::fs;
+
+mod screen;
+
+/// Command line arguments
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Run mode, only `cli` is currently supported
+    #[arg(long, default_value = "cli")]
+    mode: String,
+}
+
+/// MQTT configuration loaded from `config.toml`
+#[derive(Debug, Deserialize)]
+struct Config {
+    broker_ip: String,
+    broker_port: u16,
+    username: Option<String>,
+    password: Option<String>,
+}
+
+fn load_config() -> Config {
+    let content = fs::read_to_string("config.toml").expect("failed to read config.toml");
+    toml::from_str(&content).expect("invalid config file")
+}
+
+#[tokio::main]
+async fn main() {
+    let _args = Args::parse();
+    let cfg = load_config();
+
+    let mut options = MqttOptions::new("auto_screen_switch", cfg.broker_ip, cfg.broker_port);
+    if let (Some(u), Some(p)) = (cfg.username, cfg.password) {
+        options.set_credentials(u, p);
+    }
+
+    let (client, mut eventloop) = AsyncClient::new(options, 10);
+    client.subscribe("pi5/display", QoS::AtMostOnce).await.expect("subscribe failed");
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Incoming::Publish(p))) => {
+                match p.payload.as_ref() {
+                    b"on" => screen::set_display(true),
+                    b"off" => screen::set_display(false),
+                    _ => {}
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("MQTT error: {e}");
+                break;
+            }
+        }
+    }
+}

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,0 +1,23 @@
+#[cfg(windows)]
+use windows::Win32::Foundation::{LPARAM, WPARAM};
+#[cfg(windows)]
+use windows::Win32::UI::WindowsAndMessaging::{SendMessageW, HWND_BROADCAST, SC_MONITORPOWER, WM_SYSCOMMAND};
+
+/// Control the display power state. Only effective on Windows.
+#[cfg(windows)]
+pub fn set_display(on: bool) {
+    unsafe {
+        let state = if on { -1 } else { 2 };
+        SendMessageW(
+            HWND_BROADCAST,
+            WM_SYSCOMMAND,
+            WPARAM(SC_MONITORPOWER as usize),
+            LPARAM(state),
+        );
+    }
+}
+
+#[cfg(not(windows))]
+pub fn set_display(_on: bool) {
+    // Non-Windows platforms are not supported; this is a no-op placeholder.
+}


### PR DESCRIPTION
## Summary
- Initialize Rust binary crate targeting Windows
- Subscribe to MQTT topic and toggle monitor via Windows API
- Add configuration loading and CLI stub

## Testing
- `cargo check` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `cargo test` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_6895b683ecb88331b28bca5ac2804611