### PR TITLE
Remove Windows cfg guards

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,10 +1,9 @@
-#[cfg(windows)]
 use windows::Win32::Foundation::{LPARAM, WPARAM};
-#[cfg(windows)]
-use windows::Win32::UI::WindowsAndMessaging::{SendMessageW, HWND_BROADCAST, SC_MONITORPOWER, WM_SYSCOMMAND};
+use windows::Win32::UI::WindowsAndMessaging::{
+    SendMessageW, HWND_BROADCAST, SC_MONITORPOWER, WM_SYSCOMMAND,
+};
 
 /// Control the display power state. Only effective on Windows.
-#[cfg(windows)]
 pub fn set_display(on: bool) {
     unsafe {
         let state = if on { -1 } else { 2 };
@@ -15,9 +14,4 @@ pub fn set_display(on: bool) {
             LPARAM(state),
         );
     }
-}
-
-#[cfg(not(windows))]
-pub fn set_display(_on: bool) {
-    // Non-Windows platforms are not supported; this is a no-op placeholder.
 }


### PR DESCRIPTION
## Summary
- remove conditional compilation blocks and always target Windows APIs

## Testing
- `rustup target add x86_64-pc-windows-gnu` *(fails: unsuccessful tunnel)*
- `cargo check --target x86_64-pc-windows-gnu` *(fails: can't find crate for `core`)*
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b8be705483319dddc0a2029d76b4